### PR TITLE
Try to make dates into links

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,14 +46,14 @@
       var thisEtherpad = 'https://etherpad.mozilla.org/PDXLunchWeekOf' + thisMonday.format('DDMMMM');
       frame.src = thisEtherpad;
       var thisWeekDate = document.querySelector('.this-week-date');
-      thisWeekDate.textContent = "<a href="+thisEtherpad+">"+thisMonday.format('MMMM DD')+"</a>";
+      thisWeekDate.innerHTML = "<a href="+thisEtherpad+">"+thisMonday.format('MMMM DD')+"</a>";
 
       var nextMonday = thisMonday.add(1, 'week');
       frame = document.querySelector('.next.week iframe');
       var nextEtherpad = 'https://etherpad.mozilla.org/PDXLunchWeekOf' + nextMonday.format('DDMMMM');
       frame.src = nextEtherpad; 
       var nextWeekDate = document.querySelector('.next-week-date');
-      nextWeekDate.textContent = "<a href="+nextEtherpad+">"+nextMonday.format('MMMM DD')+"</a>";
+      nextWeekDate.innerHTML = "<a href="+nextEtherpad+">"+nextMonday.format('MMMM DD')+"</a>";
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -43,15 +43,17 @@
     <script>
       var thisMonday = moment().day(1);
       var frame = document.querySelector('.this.week iframe');
-      frame.src = 'https://etherpad.mozilla.org/PDXLunchWeekOf' + thisMonday.format('DDMMMM');
+      var thisEtherpad = 'https://etherpad.mozilla.org/PDXLunchWeekOf' + thisMonday.format('DDMMMM');
+      frame.src = thisEtherpad;
       var thisWeekDate = document.querySelector('.this-week-date');
-      thisWeekDate.textContent = thisMonday.format('MMMM DD');
+      thisWeekDate.textContent = "<a href="+thisEtherpad+">"+thisMonday.format('MMMM DD')+"</a>";
 
       var nextMonday = thisMonday.add(1, 'week');
       frame = document.querySelector('.next.week iframe');
-      frame.src = 'https://etherpad.mozilla.org/PDXLunchWeekOf' + nextMonday.format('DDMMMM');
+      var nextEtherpad = 'https://etherpad.mozilla.org/PDXLunchWeekOf' + nextMonday.format('DDMMMM');
+      frame.src = nextEtherpad; 
       var nextWeekDate = document.querySelector('.next-week-date');
-      nextWeekDate.textContent = nextMonday.format('MMMM DD');
+      nextWeekDate.textContent = "<a href="+nextEtherpad+">"+nextMonday.format('MMMM DD')+"</a>";
     </script>
   </body>
 </html>


### PR DESCRIPTION
This is probably not the right way. I couldn't get a local server to load the etherpads correctly in the amount of time I felt like spending on this. 

Ironically, the very reason I want the dates to be links is that the embedded etherpads have connection errors in the site more often than not, and I have much better luck with etherpads when they aren't stuffed into a different frame. 

It's entirely possible that the entire site and I are allergic to one another. 
